### PR TITLE
Bunch import error

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -4,5 +4,6 @@
 * [Manish Saggar](https://github.com/manishsaggar1)
 * [Rafi Ayub](https://github.com/RdoubleA)
 * [Jeff Mentch](https://github.com/jsmentch)
+* [Joseph Dehoney](https://github.com/jodahoney)
 
 _**If you contribute to DyNeuSR, feel free to add your name and email to this list!** For more information on how to contribute, please refer to the [README.md](https://github.com/braindynamicslab/dyneusr/blob/master/README.md#Support)._

--- a/dyneusr/datasets/trefoil.py
+++ b/dyneusr/datasets/trefoil.py
@@ -16,7 +16,7 @@ from itertools import product
 import numpy as np
 import pandas as pd 
 
-from sklearn.datasets.base import Bunch
+from sklearn.utils import Bunch
 
 import matplotlib as mpl
 #mpl.use('TkAgg', warn=False)


### PR DESCRIPTION
Hello, I was trying to implement the Dyneusr library in my analysis but I was coming across an error having to do with the Bunch data type import from scikit-learn. It seemed to be using a deprecated library call, so I updated it to the current documentation version as of scikit-learn 0.24.1. Also, I added my name to the contributors list.